### PR TITLE
Fixed Error and added code to unpublish app

### DIFF
--- a/PSModules/Cloud.Ready.Software.NAV/Apps/Deploy-NAVXPackage.ps1
+++ b/PSModules/Cloud.Ready.Software.NAV/Apps/Deploy-NAVXPackage.ps1
@@ -32,6 +32,7 @@
         }
         $RemoveApp | Uninstall-navapp -ServerInstance $ServerInstance -Tenant $Tenant -DoNotSaveData:$DoNotSaveData -ErrorAction Stop        
     }
+    
     # unpublish App, if Data don't has to be saved so a re-deploy of the same App Version is possible
     if ($DoNotSaveData){
         $RemoveApp = $PublishedApps | Where Name -eq $MyApp.Name | Where Publisher -eq $MyApp.Publisher | Where Version -eq $MyApp.Version

--- a/PSModules/Cloud.Ready.Software.NAV/Apps/Deploy-NAVXPackage.ps1
+++ b/PSModules/Cloud.Ready.Software.NAV/Apps/Deploy-NAVXPackage.ps1
@@ -29,7 +29,17 @@
                 }
             }
         }
-        $RemoveApp | Uninstall-navapp -ServerInstance $TargetServerInstance -Tenant $TargetTenant -DoNotSaveData:$DoNotSaveData -ErrorAction Stop        
+        $RemoveApp | Uninstall-navapp -ServerInstance $ServerInstance -Tenant $Tenant -DoNotSaveData:$DoNotSaveData -ErrorAction Stop        
+        
+        # unpublish App, if Data don't has to be saved so a re-deploy of the same App Version is possible
+        if ($DoNotSaveData){
+            $PublishedApps = Get-NAVAppInfo -ServerInstance $ServerInstance -ErrorAction Stop
+            $RemoveApp = $PublishedApps | Where Name -eq $MyApp.Name | Where Publisher -eq $MyApp.Publisher | Where Version -eq $MyApp.Version
+            if ($RemoveApp){
+                Write-Host -ForegroundColor Green "Unpublishing $($RemoveApp.Name) version $($RemoveApp.Version) from $ServerInstance"        
+                $RemoveApp | Unpublish-NAVApp -ServerInstance $ServerInstance -ErrorAction Stop 
+            }    
+        }
     }
     
     write-host -ForegroundColor Green "Publishing $($myApp.Name) version $($myApp.Version) on $ServerInstance"

--- a/PSModules/Cloud.Ready.Software.NAV/Apps/Deploy-NAVXPackage.ps1
+++ b/PSModules/Cloud.Ready.Software.NAV/Apps/Deploy-NAVXPackage.ps1
@@ -15,6 +15,7 @@
         
     )
     
+    $PublishedApps = Get-NAVAppInfo -ServerInstance $ServerInstance -ErrorAction Stop
     $InstalledApps = Get-NAVAppInfo -ServerInstance $ServerInstance -Tenant $Tenant -ErrorAction Stop
     $myApp = Get-NAVAppInfo -Path $PackageFile -ErrorAction Stop
 
@@ -33,7 +34,6 @@
         
         # unpublish App, if Data don't has to be saved so a re-deploy of the same App Version is possible
         if ($DoNotSaveData){
-            $PublishedApps = Get-NAVAppInfo -ServerInstance $ServerInstance -ErrorAction Stop
             $RemoveApp = $PublishedApps | Where Name -eq $MyApp.Name | Where Publisher -eq $MyApp.Publisher | Where Version -eq $MyApp.Version
             if ($RemoveApp){
                 Write-Host -ForegroundColor Green "Unpublishing $($RemoveApp.Name) version $($RemoveApp.Version) from $ServerInstance"        

--- a/PSModules/Cloud.Ready.Software.NAV/Apps/Deploy-NAVXPackage.ps1
+++ b/PSModules/Cloud.Ready.Software.NAV/Apps/Deploy-NAVXPackage.ps1
@@ -31,17 +31,15 @@
             }
         }
         $RemoveApp | Uninstall-navapp -ServerInstance $ServerInstance -Tenant $Tenant -DoNotSaveData:$DoNotSaveData -ErrorAction Stop        
-        
-        # unpublish App, if Data don't has to be saved so a re-deploy of the same App Version is possible
-        if ($DoNotSaveData){
-            $RemoveApp = $PublishedApps | Where Name -eq $MyApp.Name | Where Publisher -eq $MyApp.Publisher | Where Version -eq $MyApp.Version
-            if ($RemoveApp){
-                Write-Host -ForegroundColor Green "Unpublishing $($RemoveApp.Name) version $($RemoveApp.Version) from $ServerInstance"        
-                $RemoveApp | Unpublish-NAVApp -ServerInstance $ServerInstance -ErrorAction Stop 
-            }    
-        }
     }
-    
+    # unpublish App, if Data don't has to be saved so a re-deploy of the same App Version is possible
+    if ($DoNotSaveData){
+        $RemoveApp = $PublishedApps | Where Name -eq $MyApp.Name | Where Publisher -eq $MyApp.Publisher | Where Version -eq $MyApp.Version
+        if ($RemoveApp){
+            Write-Host -ForegroundColor Green "Unpublishing $($RemoveApp.Name) version $($RemoveApp.Version) from $ServerInstance"        
+            $RemoveApp | Unpublish-NAVApp -ServerInstance $ServerInstance -ErrorAction Stop 
+        }    
+    }
     write-host -ForegroundColor Green "Publishing $($myApp.Name) version $($myApp.Version) on $ServerInstance"
     Publish-NAVApp -Path $PackageFile -ServerInstance $ServerInstance -ErrorAction Stop
 


### PR DESCRIPTION
In line 32 there was an error thrown, because variables $TargetServerInstance and $TargetTenant were used instead of $ServerInstance and $Tenant.
In line 18 and 36 code was added to get the published apps and unpublish the app before publishing it, so it is possible to re-deploy the same version of an app if the data don't has to be saved.
