### PR TITLE
Changed Licence Import

### DIFF
--- a/PSModules/Cloud.Ready.Software.NAV/New-NAVEnvironment.ps1
+++ b/PSModules/Cloud.Ready.Software.NAV/New-NAVEnvironment.ps1
@@ -44,18 +44,20 @@
     Invoke-SQL `
         -DatabaseServer $ServerInstanceObject.DatabaseServer `
         -DatabaseInstance $ServerInstanceObject.DatabaseInstance `
-        -DatabaseName $ServerInstanceObject.DatabaseName `        -SQLCommand $SQLCommand `
+        -DatabaseName $ServerInstanceObject.DatabaseName `
+        -SQLCommand $SQLCommand `
         -ErrorAction SilentlyContinue
     Invoke-SQL `
         -DatabaseServer $ServerInstanceObject.DatabaseServer `
         -DatabaseInstance $ServerInstanceObject.DatabaseInstance `
-        -DatabaseName $ServerInstanceObject.DatabaseName `        -SQLCommand "ALTER ROLE [db_owner] ADD MEMBER [$($ServerInstanceObject.ServiceAccount)]" `
+        -DatabaseName $ServerInstanceObject.DatabaseName `
+        -SQLCommand "ALTER ROLE [db_owner] ADD MEMBER [$($ServerInstanceObject.ServiceAccount)]" `
         -ErrorAction SilentlyContinue
          
     $null = Set-NAVServerInstance -Start -ServerInstance $ServerInstance
     if($LicenseFile){  
         Write-Host -ForegroundColor Green -Object 'Importing license..'
-        $null = $ServerInstanceObject | Import-NAVServerLicense -LicenseFile $LicenseFile -Force -WarningAction SilentlyContinue
+        $null = $ServerInstanceObject | Import-NAVServerLicense -LicenseFile $LicenseFile -Database NavDatabase -Force -WarningAction SilentlyContinue
     }
             
     if ($EnablePortSharing) {


### PR DESCRIPTION
Hi Waldo,

i've got an error while importing NAV license, because the user I used did not have the rights to update the master database on SQL Server.
I added the parameter and value "-Database NavDatabase" to the Import-NAVServerLicense command in line 60, so the licence will only be added for the current NAV Database, where the user have the rights to update the NAV License.
In my opinion, NAV licenses should only be valid for the database and not for all databases on SQL Server, so i decided not to use an additional parameter for this cmdlet.
