### PR TITLE
Update CreateISOandZipOnAzureImage.ps1

### DIFF
--- a/PSScripts/NAV Developer Tools/CreateISOandZipOnAzureImage.ps1
+++ b/PSScripts/NAV Developer Tools/CreateISOandZipOnAzureImage.ps1
@@ -9,6 +9,7 @@ Find-Module | where author -eq waldo | Install-Module
 Import-Module -Name Cloud.Ready.Software.NAV
 
 #DVD
+New-Item -ItemType Directory -Force -Path 'C:\DOWNLOAD' | Out-Null
 New-ISOFileFromFolder -FilePath 'C:\NAVDVD\US' -Name 'NAVDVD' -ResultFullFileName 'C:\DOWNLOAD\NAVDVD.iso'
 
 #DEVTools


### PR DESCRIPTION
Added "create DOWNLOAD folder" to script. Apparently this isn't existing in all the azure ISOs. No test-path before, just force.