### PR TITLE
Update Start-NAVUpgradeDatabase.ps1

### DIFF
--- a/PSModules/Cloud.Ready.Software.NAV/Upgrade/Start-NAVUpgradeDatabase.ps1
+++ b/PSModules/Cloud.Ready.Software.NAV/Upgrade/Start-NAVUpgradeDatabase.ps1
@@ -77,6 +77,10 @@
     Invoke-SQL -DatabaseName $SandboxServerInstance -SQLCommand 'DISABLE TRIGGER [dbo].[REVISION_INSERT] ON [dbo].[Object]' -ErrorAction silentlyContinue
     Invoke-SQL -DatabaseName $SandboxServerInstance -SQLCommand 'DISABLE TRIGGER [dbo].[REVISION_DELETE] ON [dbo].[Object]' -ErrorAction silentlyContinue
 
+    #Clear Dynamics NAV Server instance and debugger breakpoint records from old database
+    Invoke-SQL -DatabaseName $SandboxServerInstance -SQLCommand 'DELETE FROM [dbo].[Server Instance]' -ErrorAction silentlyContinue
+    Invoke-SQL -DatabaseName $SandboxServerInstance -SQLCommand 'DELETE FROM [dbo].[Debugger Breakpoint]' -ErrorAction silentlyContinue
+
     #Convert DB
     Write-Host 'Converting Database' -ForegroundColor Green
     [System.Data.SqlClient.SqlConnection]::ClearAllPools()


### PR DESCRIPTION
Added the necessary SQL commands to delete data from the two tables:
- Server Instance
- Debugger Breakpoint

Any data in these two tables will cause failure during Invoke-NAVDatabaseConversion.