### PR TITLE
V18 changes required

### DIFF
--- a/PSModules/Cloud.Ready.Software.NAV/Upgrade/Versions.json
+++ b/PSModules/Cloud.Ready.Software.NAV/Upgrade/Versions.json
@@ -83,17 +83,17 @@
 			"downloadLinkRegex" : ""
 		},
 		{
-<<<<<<< Updated upstream
-			"version": "BC17",
-			"url": "https://support.microsoft.com/en-gb/help/4583507",
-			"fileNamePrefix" : "BC",
-			"CULinkRegex" : "",
-=======
 			"version": "BC18",
 			"url": "https://support.microsoft.com/en-us/help/5003500",
 			"fileNamePrefix" : "BC",
 			"CUNoRegex" : "",
->>>>>>> Stashed changes
+			"downloadLinkRegex" : ""
+		},
+		{
+			"version": "BC19",
+			"url": "https://support.microsoft.com/en-us/help/5007780",
+			"fileNamePrefix" : "BC",
+			"CUNoRegex" : "",
 			"downloadLinkRegex" : ""
 		}
 	],

--- a/PSModules/Cloud.Ready.Software.NAV/Upgrade/Versions.json
+++ b/PSModules/Cloud.Ready.Software.NAV/Upgrade/Versions.json
@@ -1,6 +1,6 @@
 {
 	"DefaultDownloadURL" : "https://support.microsoft.com",
-	"BuildRegex" : "\\(Build ([\\d\\.]+)\\)|Platform Build (\\d+\\.?\\d+\\.?\\d+)\\.?\\d?\\)",
+	"BuildRegex" : "\\(Build ([\\d\\.]+)\\)|Platform Build (\\d+\\.?\\d+\\.?\\d+)\\.?\\d*\\)",
 	"CountryCodeRegex" : "\\.([A-Z]{2}|W1).DVD|(?:\\.)?([A-Z]{2}|W1)\\.ZIP",
 	"CUNoRegex" : "(?:Cumulative )?Update (\\d\\d?\\.?\\d{0,2})",
 	"downloadLinkRegex" : "(https?\\:\\\/\\\/www\\.microsoft\\.com\\\/(?:[a-z]{2}-[a-z]{2}\\\/)?download\\\/details.aspx\\?(?:familyid=([\\da-zA-Z]{8}-(?:[\\da-zA-Z]{4}-){3}[\\da-zA-Z]{12})|id(?:%3d|=)?(\\d+)))",
@@ -83,10 +83,17 @@
 			"downloadLinkRegex" : ""
 		},
 		{
+<<<<<<< Updated upstream
 			"version": "BC17",
 			"url": "https://support.microsoft.com/en-gb/help/4583507",
 			"fileNamePrefix" : "BC",
 			"CULinkRegex" : "",
+=======
+			"version": "BC18",
+			"url": "https://support.microsoft.com/en-us/help/5003500",
+			"fileNamePrefix" : "BC",
+			"CUNoRegex" : "",
+>>>>>>> Stashed changes
 			"downloadLinkRegex" : ""
 		}
 	],


### PR DESCRIPTION
Microsoft has changed a couple of things with CU page and also the url for the download links.  For some reason link to the downloads is now "regionalized" to en-gb rather than en-us.  Therefore I had to update the GetDownloadLocales function in the MicrosoftDownloadParser class.  I checked with people in Sweden and the US to make sure it is the same for them (as I am in GB) and it is.  The function will check for either en-us or en-gb now.  

It may not be the most elegant C# code but I am not sure if all the new features in C# are supported in PowerShell versions so I tried to keep it simple.