### PR TITLE
Update Get-NAVModuleVersions to remove nonexistent search paths

### DIFF
--- a/PSModules/Cloud.Ready.Software.NAV/Get-NAVModuleVersions.ps1
+++ b/PSModules/Cloud.Ready.Software.NAV/Get-NAVModuleVersions.ps1
@@ -41,6 +41,8 @@ function Get-NAVModuleVersions {
                 )
     }
 
+    $searchIn = $searchIn | Where-Object { Test-Path $_ }
+
     foreach ($searchPath in $searchIn) {
         
         Write-Verbose "Searching in $searchPath, please wait a second..."


### PR DESCRIPTION
This PR adds a filter to the paths used in "Get-NAVModuleVersions.ps1" to remove all nonexistent paths. This reduces the numbers of calls necessary and might also resolve possible reading permission errors in older versions of PowerShell.